### PR TITLE
Replace dead variables article with working equivalent

### DIFF
--- a/README.org
+++ b/README.org
@@ -128,9 +128,9 @@ For a more general index related to all-things Emacs, use [[https://github.com/e
 
     Written by [[#caio-rordrigues-caiorss][Caio Rordrigues (@caiorss)]].
 
-*** (Almost) All You Need to Know About Variables
+*** What you need to know about variables in Emacs
 
-    [[https://with-emacs.com/posts/tutorials/almost-all-you-need-to-know-about-variables/][read online]]
+    [[https://opensource.com/article/20/3/variables-emacs][read online]]
 
     A must read!
 


### PR DESCRIPTION
Replace dead URL with equivalent article written by the same author, Clemens Radermacher, but published to opensource.com.

Compare the [opensource.com](https://opensource.com/article/20/3/variables-emacs) article to the archive.org capture of the [original](https://web.archive.org/web/20221120084749/https://with-emacs.com/posts/tutorials/almost-all-you-need-to-know-about-variables/):

Fixes issue #23